### PR TITLE
Adds types for Service, SuspensionDetails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,9 @@ dist
 /RUNNING_PID
 /.settings
 *.iws
-
-    
+.bloop
+.bsp
+project/metals.sbt
+.metals
+.vscode
+.DS_Store

--- a/src/main/scala/uk/gov/hmrc/agentclientauthorisation/model/Service.scala
+++ b/src/main/scala/uk/gov/hmrc/agentclientauthorisation/model/Service.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.model
+
+import play.api.libs.json.Format
+import uk.gov.hmrc.agentmtdidentifiers.model._
+import uk.gov.hmrc.domain.{Nino, SimpleObjectReads, SimpleObjectWrites, TaxIdentifier}
+
+sealed abstract class Service(
+  val id: String,
+  val invitationIdPrefix: Char,
+  val enrolmentKey: String,
+  val supportedSuppliedClientIdType: ClientIdType[_ <: TaxIdentifier],
+  val supportedClientIdType: ClientIdType[_ <: TaxIdentifier],
+  val requiresKnownFactsCheck: Boolean) {
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: Service => this.id.equals(that.id)
+      case _             => false
+    }
+}
+
+object Service {
+
+  val HMRCMTDIT = "HMRC-MTD-IT"
+
+  val HMRCPIR = "PERSONAL-INCOME-RECORD"
+
+  val HMRCMTDVAT = "HMRC-MTD-VAT"
+
+  val HMRCTERSORG = "HMRC-TERS-ORG"
+
+  val HMRCTERSNTORG = "HMRC-TERSNT-ORG"
+
+  val HMRCCGTPD = "HMRC-CGT-PD"
+
+  val HMRCPPTORG = "HMRC-PPT-ORG"
+
+  case object MtdIt extends Service("HMRC-MTD-IT", 'A', "HMRC-MTD-IT", NinoType, MtdItIdType, true)
+
+  case object PersonalIncomeRecord extends Service("PERSONAL-INCOME-RECORD", 'B', "HMRC-NI", NinoType, NinoType, false)
+
+  case object Vat extends Service("HMRC-MTD-VAT", 'C', "HMRC-MTD-VAT", VrnType, VrnType, false)
+
+  case object Trust extends Service("HMRC-TERS-ORG", 'D', "HMRC-TERS-ORG", UtrType, UtrType, false)
+
+  case object TrustNT extends Service("HMRC-TERSNT-ORG", 'F', "HMRC-TERSNT-ORG", UrnType, UrnType, false)
+
+  case object CapitalGains extends Service("HMRC-CGT-PD", 'E', "HMRC-CGT-PD", CgtRefType, CgtRefType, true)
+
+  case object Ppt extends Service("HMRC-PPT-ORG", 'G', "HMRC-PPT-ORG", PptRefType, PptRefType, true)
+
+  val supportedServices: Seq[Service] = Seq(MtdIt, Vat, PersonalIncomeRecord, Trust, TrustNT, CapitalGains, Ppt)
+
+  def findById(id: String): Option[Service] = supportedServices.find(_.id == id)
+  def forId(id: String): Service = findById(id).getOrElse(throw new Exception("Not a valid service"))
+  def forInvitationId(invitationId: InvitationId): Option[Service] =
+    supportedServices.find(_.invitationIdPrefix == invitationId.value.head)
+
+  def apply(id: String) = forId(id)
+  def unapply(service: Service): Option[String] = Some(service.id)
+
+  val reads = new SimpleObjectReads[Service]("id", Service.apply)
+  val writes = new SimpleObjectWrites[Service](_.id)
+  implicit val format = Format(reads, writes)
+
+}
+
+sealed abstract class ClientIdType[+T <: TaxIdentifier](
+  val clazz: Class[_],
+  val id: String,
+  val enrolmentId: String,
+  val createUnderlying: String => T) {
+  def isValid(value: String): Boolean
+}
+
+object ClientIdType {
+  val supportedTypes = Seq(NinoType, MtdItIdType, VrnType, UtrType, UrnType, CgtRefType, PptRefType)
+  def forId(id: String) =
+    supportedTypes.find(_.id == id).getOrElse(throw new IllegalArgumentException("Invalid id:" + id))
+}
+
+case object NinoType extends ClientIdType(classOf[Nino], "ni", "NINO", Nino.apply) {
+  override def isValid(value: String): Boolean = Nino.isValid(value)
+}
+
+case object MtdItIdType extends ClientIdType(classOf[MtdItId], "MTDITID", "MTDITID", MtdItId.apply) {
+  override def isValid(value: String): Boolean = MtdItId.isValid(value)
+}
+
+case object VrnType extends ClientIdType(classOf[Vrn], "vrn", "VRN", Vrn.apply) {
+  override def isValid(value: String) = Vrn.isValid(value)
+}
+
+case object UtrType extends ClientIdType(classOf[Utr], "utr", "SAUTR", Utr.apply) {
+  override def isValid(value: String) = value.matches("^\\d{10}$")
+}
+
+case object UrnType extends ClientIdType(classOf[Urn], "urn", "URN", Urn.apply) {
+  override def isValid(value: String) = value.matches("^([A-Z0-9]{1,15})$")
+}
+
+case object CgtRefType extends ClientIdType(classOf[CgtRef], "CGTPDRef", "CGTPDRef", CgtRef.apply) {
+  override def isValid(value: String): Boolean = CgtRef.isValid(value)
+}
+
+case object PptRefType extends ClientIdType(classOf[PptRef], "EtmpRegistrationNumber", "EtmpRegistrationNumber", PptRef.apply) {
+  override def isValid(value: String): Boolean = PptRef.isValid(value)
+}
+
+case class ClientIdentifier[T <: TaxIdentifier](underlying: T) {
+
+  private val clientIdType = ClientIdType.supportedTypes
+    .find(_.clazz == underlying.getClass)
+    .getOrElse(throw new Exception("Invalid type for clientId " + underlying.getClass.getCanonicalName))
+
+  val value: String = underlying.value
+  val typeId: String = clientIdType.id
+  val enrolmentId: String = clientIdType.enrolmentId
+
+  override def toString: String = value
+}
+
+object ClientIdentifier {
+  type ClientId = ClientIdentifier[_ <: TaxIdentifier]
+
+  def apply(value: String, typeId: String): ClientId =
+    ClientIdType.supportedTypes
+      .find(_.id == typeId)
+      .getOrElse(throw new IllegalArgumentException("Invalid Client Id Type: " + typeId))
+      .createUnderlying(value.replaceAll("\\s", ""))
+
+  implicit def wrap[T <: TaxIdentifier](taxId: T): ClientIdentifier[T] = ClientIdentifier(taxId)
+}

--- a/src/main/scala/uk/gov/hmrc/agentclientauthorisation/model/SuspensionDetails.scala
+++ b/src/main/scala/uk/gov/hmrc/agentclientauthorisation/model/SuspensionDetails.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.model
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.agentclientauthorisation.model.Service._
+
+case class SuspensionDetails(suspensionStatus: Boolean, suspendedRegimes: Set[String]) {
+
+  def isRegimeSuspended(service: Service): Boolean = {
+    val regime = SuspensionDetails.serviceToRegime(service)
+    suspendedRegimes.contains(regime)
+  }
+
+  def isRegimeSuspended(id: String): Boolean = {
+    def idToService(id: String): Service = {
+      SuspensionDetails.serviceToRegime
+        .find(_._1.id == id)
+        .map(_._1)
+        .getOrElse(throw new IllegalArgumentException(s"Service of ID '$id' not known"))
+    }
+
+    val regime = SuspensionDetails.serviceToRegime(idToService(id))
+    suspendedRegimes.contains(regime)
+  }
+
+  def suspendedRegimesForServices(serviceIds: Set[String]): Set[String] = {
+    SuspensionDetails.serviceToRegime
+      .filterKeys(s => serviceIds.contains(s.id)).values.toSet
+      .intersect(suspendedRegimes)
+  }
+
+  def isAnyRegimeSuspendedForServices(ids: Set[String]): Boolean = suspendedRegimesForServices(ids).nonEmpty
+
+  override def toString: String = suspendedRegimes.toSeq.sorted.mkString(",")
+
+}
+
+object SuspensionDetails {
+
+  lazy val serviceToRegime: Map[Service, String] =
+    Map(MtdIt -> "ITSA", Vat -> "VATC", Trust -> "TRS", TrustNT -> "TRS", CapitalGains -> "CGT", Ppt -> "PPT")
+
+  //PERSONAL-INCOME-RECORD service has no enrolment / regime so cannot be suspended
+  lazy val validSuspensionRegimes: Set[String] = serviceToRegime.filterKeys(Seq(MtdIt, Vat, Trust, CapitalGains, Ppt).contains(_)).values.toSet
+
+  def apply(suspensionStatus: Boolean, regimes: Option[Set[String]]): SuspensionDetails = {
+    val suspendedRegimes =
+      regimes.fold(Set.empty[String])(rs => if (rs.contains("ALL") || rs.contains("AGSV")) validSuspensionRegimes else rs)
+
+    new SuspensionDetails(suspensionStatus, suspendedRegimes)
+  }
+
+  implicit val formats: OFormat[SuspensionDetails] = Json.format
+
+  val notSuspended = SuspensionDetails(suspensionStatus = false, None)
+}
+
+case class SuspensionDetailsNotFound(message: String) extends Exception(message)

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Arn.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Arn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/CgtRef.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/CgtRef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Eori.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Eori.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/InvitationId.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/InvitationId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/MtdItId.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/MtdItId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/PptRef.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/PptRef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/TrustTaxIdentifier.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/TrustTaxIdentifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Urn.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Urn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Utr.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Utr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Vrn.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/model/Vrn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/utils/TaxIdentifierFormatters.scala
+++ b/src/main/scala/uk/gov/hmrc/agentmtdidentifiers/utils/TaxIdentifierFormatters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentclientauthorisation/model/SuspensionDetailsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentclientauthorisation/model/SuspensionDetailsSpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientauthorisation.model
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.Json.toJson
+import uk.gov.hmrc.agentclientauthorisation.model.Service.{HMRCCGTPD, HMRCMTDIT}
+
+class SuspensionDetailsSpec extends WordSpec with Matchers {
+
+  val suspensionStatusTrue = true
+  val inputRegimes = Set("aRegime", "bRegime")
+
+  "Suspended regimes" should {
+    "be empty set when input regimes set is not present" in {
+      val regimes = None
+
+      val suspensionDetails = SuspensionDetails(suspensionStatusTrue, regimes)
+
+      suspensionDetails.suspendedRegimes shouldBe Set.empty[String]
+    }
+
+    "be empty set when input regimes set is empty" in {
+      val regimes = Some(Set.empty[String])
+
+      val suspensionDetails = SuspensionDetails(suspensionStatusTrue, regimes)
+
+      suspensionDetails.suspendedRegimes shouldBe Set.empty[String]
+    }
+
+    "be all valid suspension regimes when input regimes contains 'ALL' or 'AGSV'" in {
+      SuspensionDetails(suspensionStatusTrue, Some(inputRegimes + "ALL")).suspendedRegimes shouldBe Set("ITSA", "PPT", "TRS", "VATC", "CGT")
+      SuspensionDetails(suspensionStatusTrue, Some(inputRegimes + "AGSV")).suspendedRegimes shouldBe Set("ITSA", "PPT", "TRS", "VATC", "CGT")
+    }
+
+    "match provided regimes when input does not contain either 'ALL' or 'AGSV'" in {
+      SuspensionDetails(suspensionStatusTrue, Some(inputRegimes)).suspendedRegimes shouldBe Set("aRegime", "bRegime")
+    }
+
+  }
+
+  "isRegimeSuspended" should {
+
+    def getServiceOfRegimeName(regimeName: String): Service = SuspensionDetails.serviceToRegime.find(_._2 == regimeName).get._1
+
+    "return false when input regime names do not match well-defined regime names AND input regime names do not contain either 'ALL' or 'AGSV'" in {
+      val regimes = Some(inputRegimes)
+
+      val suspensionDetails = SuspensionDetails(suspensionStatusTrue, regimes = regimes)
+
+      SuspensionDetails.validSuspensionRegimes foreach { regimeName =>
+        val service = getServiceOfRegimeName(regimeName)
+
+        suspensionDetails.isRegimeSuspended(service) shouldBe false
+      }
+    }
+
+    "return true when input regime names do not match well-defined regime names BUT input regime names contains 'ALL' or 'AGSV'" in {
+      SuspensionDetails.validSuspensionRegimes foreach { regimeName =>
+        val service = getServiceOfRegimeName(regimeName)
+
+        SuspensionDetails(suspensionStatusTrue, regimes = Some(inputRegimes + "ALL")).isRegimeSuspended(service) shouldBe true
+        SuspensionDetails(suspensionStatusTrue, regimes = Some(inputRegimes + "AGSV")).isRegimeSuspended(service) shouldBe true
+      }
+    }
+
+    "return true when input regimes include well-defined values" in {
+      SuspensionDetails.serviceToRegime.keySet foreach { service =>
+        val suspensionDetails = SuspensionDetails(suspensionStatusTrue, regimes = Some(Set(SuspensionDetails.serviceToRegime(service))))
+
+        suspensionDetails.isRegimeSuspended(service) shouldBe true
+      }
+    }
+
+    "return true when the regime is suspended" in {
+      SuspensionDetails(suspensionStatus = true, Some(Set("ITSA", "VATC"))).isRegimeSuspended(HMRCMTDIT) shouldBe true
+    }
+
+    "return true when ALL regimes are suspended" in {
+      SuspensionDetails(suspensionStatus = true, Some(Set("ALL"))).isRegimeSuspended(HMRCMTDIT) shouldBe true
+    }
+
+    "return false when the regime is not suspended" in {
+      SuspensionDetails(suspensionStatus = true, Some(Set("ITSA", "VATC")))
+        .isRegimeSuspended(HMRCCGTPD) shouldBe false
+    }
+  }
+
+  "suspendedRegimesForServices" should {
+    "return only the suspended regimes" in {
+      SuspensionDetails(suspensionStatus = true, Some(Set("ITSA", "VATC")))
+        .suspendedRegimesForServices(Set(HMRCMTDIT, HMRCCGTPD)) shouldBe Set("ITSA")
+    }
+
+    "return all of the regimes if ALL are suspended" in {
+      SuspensionDetails(suspensionStatus = true, Some(Set("ALL")))
+        .suspendedRegimesForServices(Set(HMRCMTDIT, HMRCCGTPD)) shouldBe Set("ITSA", "CGT")
+    }
+  }
+
+  "isAnyRegimeSuspendedForServices" should {
+    "return true if the agent is suspended for any regimes in the consents" in {
+      SuspensionDetails(suspensionStatus = true, Some(Set("ITSA", "VATC")))
+        .isAnyRegimeSuspendedForServices(Set(HMRCMTDIT)) shouldBe true
+    }
+    "return false if the agent is not suspended for any service in the consents" in {
+      SuspensionDetails(suspensionStatus = true, Some(Set("ITSA", "VATC")))
+        .isAnyRegimeSuspendedForServices(Set(HMRCCGTPD)) shouldBe false
+    }
+  }
+
+  "JSON conversion" should {
+    "contain 'suspendedRegimes' element with values matching input regimes when they do not contain either 'ALL' or 'AGSV'" in {
+      val suspensionDetails = SuspensionDetails(suspensionStatus = suspensionStatusTrue, regimes = Some(inputRegimes))
+
+      val json = toJson(suspensionDetails)
+
+      (json \ "suspensionStatus").as[Boolean] shouldBe true
+      (json \ "suspendedRegimes").as[Set[String]] shouldBe Set("aRegime", "bRegime")
+    }
+
+    "contain 'suspendedRegimes' element with all valid suspension regimes when input contains 'ALL' or 'AGSV'" in {
+      Seq("ALL", "AGSV") foreach { regime =>
+        val suspensionDetails = SuspensionDetails(suspensionStatus = suspensionStatusTrue, regimes = Some(inputRegimes + regime))
+
+        val json = toJson(suspensionDetails)
+
+        (json \ "suspensionStatus").as[Boolean] shouldBe true
+        (json \ "suspendedRegimes").as[Set[String]] shouldBe Set("ITSA", "PPT", "TRS", "VATC", "CGT")
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/ArnSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/ArnSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/CgtRefSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/CgtRefSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/EoriSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/EoriSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/InvitationIdSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/InvitationIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/MtdItIdSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/MtdItIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/PptRefSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/PptRefSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/UrnSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/UrnSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/UtrSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/UtrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/VrnSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/VrnSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/utils/TaxIdentifierFromattersSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/utils/TaxIdentifierFromattersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
A few case class definitions are duplicated across projects like `agent-invitations-frontend`, `agent-client-authorisation`, `agent-services-account-frontend`, `agent-helpdesk-frontend`, and `agent-client-management-frontend`.

This pull request will consolidate some of those duplicates into `agent-mtd-identifiers`. Dependent client applications will be separately refactored to stop using their own version of these classes, and start using the consolidated classes being introduced in this pull request.