### PR TITLE
 Option 1 [CS] update AccessGroup model for groups by tax service

### DIFF
--- a/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/AccessGroupSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/agentmtdidentifiers/model/AccessGroupSpec.scala
@@ -49,7 +49,9 @@ class AccessGroupSpec extends FlatSpec with Matchers {
           agent,
           agent,
           Some(Set(agent, user1, user2)),
-          Some(Set(client1, client2, client3))
+          Some(Set(client1, client2, client3)),
+          None,
+          None
         )
 
       val jsonString =


### PR DESCRIPTION
Opinions on this change? Seems simple enough but it feels like maybe we need 2 separate case classes for `CustomAccessGroup` and `TaxServiceAccessGroup` for safety - although that impacts a lot in `agent-permissions` with all the methods currently using `AccessGroup` for CRUD